### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/VladimirKhil/SIStatisticsService/security/code-scanning/2](https://github.com/VladimirKhil/SIStatisticsService/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only performs read operations (e.g., checking out the repository and restoring dependencies), we will set `contents: read` as the minimal required permission. This ensures the workflow has the least privileges necessary to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
