### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+permissions:
+  contents: read
+
 on:
   release:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/VladimirKhil/SIStatisticsService/security/code-scanning/1](https://github.com/VladimirKhil/SIStatisticsService/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow primarily involves reading repository contents and does not require write permissions, we can set `contents: read` at the workflow level. This ensures that the `GITHUB_TOKEN` has minimal permissions, adhering to the principle of least privilege.

The changes will be made to the `.github/workflows/release.yml` file:
1. Add a `permissions` block at the root level of the workflow, specifying `contents: read`.
2. Ensure no unnecessary write permissions are granted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
